### PR TITLE
Fix bootstrap script path

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,7 +12,7 @@ fi
 # --- Step 1: ensure host module exists --------------------------------------------------
 
 sudo chmod +x /etc/nixos/scripts/*
-/etc/nixos/bootstrap/update-hostname.sh
+/etc/nixos/scripts/update-hostname.sh
  
 # --- Step 2: create read-only deploy key on GitHub --------------------------------------
 


### PR DESCRIPTION
## Summary
- ensure the hostname update script is invoked using the correct path

## Testing
- `bash -n scripts/bootstrap.sh`

------
https://chatgpt.com/codex/tasks/task_e_6882127a2418832bb098ab33db3658b2